### PR TITLE
Gitlab ci ignore release fail

### DIFF
--- a/lib/generators/rys/plugin/templates/.gitlab-ci.yml.tt
+++ b/lib/generators/rys/plugin/templates/.gitlab-ci.yml.tt
@@ -23,6 +23,7 @@ Me:
   stage: ryses
   script:
     - ruby $TESTER rys test_me --adapter postgresql
+  coverage: '/\(\d+.\d+\%\) covered/'
 
 Ryses:
   stage: ryses
@@ -40,3 +41,4 @@ Release:
     - master
   script:
     - ruby $TESTER release_gem release
+  allow_failure: true


### PR DESCRIPTION
* Ignore fail on release stage = for some reason I dont want increase version of RYS, but I pushing to master branch = it fail
* calculate coverage without gitlab setting 🙂 