### PR TITLE
add missing extensions in redmine

### DIFF
--- a/lib/rys.rb
+++ b/lib/rys.rb
@@ -13,5 +13,7 @@ module Rys
   end
 end
 
+require 'redmine_extensions'
+require 'rys_management'
 require 'rys/engine'
 require 'rys/featured_routes'

--- a/rys.gemspec
+++ b/rys.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'request_store'
   s.add_dependency 'tty-prompt'
   s.add_dependency 'redmine_extensions'
+  s.add_dependency 'rys_management'
 end


### PR DESCRIPTION
In Redmine (no EP/ER) missing
1. redmine_extensions
2. rys_management

So when I create gem which is for both worlds (redmine + ep) I need add these dependencies manually. 

Why its not already part of RYS ? 