### PR TITLE
optimize #registered_for

### DIFF
--- a/app/models/rys_feature_record.rb
+++ b/app/models/rys_feature_record.rb
@@ -17,7 +17,7 @@ class RysFeatureRecord < ActiveRecord::Base
       end
     end
 
-    where(name: features.map(&:full_key))
+    features.any? ? where(name: features.map(&:full_key)) : none
   }
 
   after_commit :update_callback, on: :update


### PR DESCRIPTION
skips an impossible `WHERE (1=0)` query