### PR TITLE
uninstallation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- uninstallation
 
 ## [2.0.4] - 2022-04-04
 ### Removed

--- a/lib/rys/migrate.rb
+++ b/lib/rys/migrate.rb
@@ -19,8 +19,10 @@ module Rys
 
       # @param [String] source - +migrate+ or +after_plugins+
       def call(source)
+        names = ENV['NAME'].to_s.split(",").map(&:strip)
         PluginsManagement.all(systemic: true) do |plugin|
-          version = ENV['VERSION'].presence
+          version = ENV['VERSION'].to_i if ENV['VERSION'].present?
+          next unless names.include?(plugin.rys_id) if ENV['NAME'].present?
           existent_dirs = plugin.paths["db/#{source}"].existent
 
           puts "Migrating #{plugin} #{source} ..."

--- a/lib/rys/version.rb
+++ b/lib/rys/version.rb
@@ -1,5 +1,5 @@
 module Rys
 
-  VERSION = '2.0.4'
+  VERSION = '2.0.5'
   
 end


### PR DESCRIPTION
rake rys:migrate:after_plugins NAME=easy_b2b VERSION=0 RAILS_ENV=production
rake rys:migrate:plugins NAME=easy_b2b VERSION=0 RAILS_ENV=production