### PR TITLE
remove deprecated warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## [Unreleased]
+
+## [3.0.1] - 2023-12-14
+### Changed
+- easy_patches are no longer deprecated - in core of ER we will use them because of order
+
+## [3.0.0] - 2023-10-06
 ### Fixed
 - uninstallation
 ### Added

--- a/lib/rys/engine_extensions.rb
+++ b/lib/rys/engine_extensions.rb
@@ -19,11 +19,6 @@ module Rys
         easy_patch_dir = base.root.join("easy_patch")
         if easy_patch_dir.exist?
           Dir.glob(easy_patch_dir.join('**/*.rb')).each do |patch_file|
-            EasyDeprecation.warn(
-              deprecated: "Easy Patch (#{patch_file}) in RYS",
-              new_solution: "Rys::Patcher",
-              documentation_link: "https://developers.easysoftware.com/docs/developer-portal-devs/ZG9jOjM5NzgxNzQz-patch-management"
-            )
             require patch_file
           end
         end

--- a/lib/rys/version.rb
+++ b/lib/rys/version.rb
@@ -1,5 +1,5 @@
 module Rys
 
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
   
 end


### PR DESCRIPTION
in core engines in ER we are still using `EasyPatchManager` because of order priority. In regular RYS we stay using Rys::Patcher.


## Main difference - `EasyPatchManager` vs. `Rys::Patcher`


| EasyPatchManager | Rys::Patcher  | 
|--------------------|-------------|
| load_path: `easy_patch` | load_path: `patches` |
| `included` by default | `prepended` by default |
| applied 2nd in order, after `if EasyProjectLoader.can_start?` in `after_plugins_loaded` => which means after all plugins are loaded  | applied 1st in order by `Rys.apply_patches! `, but in fact with same condition as `EasyProjectLoader.can_start?`, before plugins |
| used in all plugins and easy_engines | used only in RYSy |